### PR TITLE
Feat: 프로필 설정 비동기 통신

### DIFF
--- a/components/Keyword.tsx
+++ b/components/Keyword.tsx
@@ -3,18 +3,18 @@ import styled from 'styled-components';
 
 interface KeywordButtonProps {
   text: string;
-  isClicked: (clicked: boolean) => void;
+  onClicked: (clicked: boolean, text: string) => void;
 }
 
-export default function Keyword({ text, isClicked }: KeywordButtonProps) {
+export default function Keyword({ text, onClicked }: KeywordButtonProps) {
   const [onclick, setOnclick] = useState(false);
 
   const onClickKeyword = () => {
     setOnclick(!onclick);
-    isClicked(onclick);
+    onClicked(onclick, text);
   };
   return (
-    <StyledKeywordButton onClick={onClickKeyword} clicked={onclick} isClicked={isClicked}>
+    <StyledKeywordButton onClick={onClickKeyword} clicked={onclick} onclicked={onClicked}>
       {text}
     </StyledKeywordButton>
   );

--- a/core/api/userprofileAPI.ts
+++ b/core/api/userprofileAPI.ts
@@ -4,8 +4,7 @@ import { UserProfileProps } from '../../types/user';
 export const userprofileAPI = async (userprofile: UserProfileProps) => {
   try {
     const res = await axios.post('/userprofile', {
-      topic: userprofile.topic,
-      value: userprofile.value,
+      userprofile,
     });
     return res.data;
   } catch (error) {

--- a/core/api/userprofileAPI.ts
+++ b/core/api/userprofileAPI.ts
@@ -1,0 +1,14 @@
+import axios from 'axios';
+import { UserProfileProps } from '../../types/user';
+
+export const userprofileAPI = async (userprofile: UserProfileProps) => {
+  try {
+    const res = await axios.post('/userprofile', {
+      topic: userprofile.topic,
+      value: userprofile.value,
+    });
+    return res.data;
+  } catch (error) {
+    console.error(error);
+  }
+};

--- a/core/recoil/userProfileAtom.ts
+++ b/core/recoil/userProfileAtom.ts
@@ -1,0 +1,10 @@
+import { atom } from 'recoil';
+import { UserProfileProps } from '../../types/user';
+
+export const userProfileState = atom<UserProfileProps>({
+  key: 'userProfileState',
+  default: {
+    topic: '',
+    value: '',
+  },
+});

--- a/core/recoil/userProfileAtom.ts
+++ b/core/recoil/userProfileAtom.ts
@@ -1,10 +1,6 @@
 import { atom } from 'recoil';
-import { UserProfileProps } from '../../types/user';
 
-export const userProfileState = atom<UserProfileProps>({
+export const userProfileState = atom<object[]>({
   key: 'userProfileState',
-  default: {
-    topic: '',
-    value: '',
-  },
+  default: [],
 });

--- a/mocks/handlers/index.ts
+++ b/mocks/handlers/index.ts
@@ -1,4 +1,5 @@
 import { registerHandlers } from './register';
 import { loginHandlers } from './login';
+import { profileHandlers } from './profile';
 
-export const handlers = [...registerHandlers, ...loginHandlers];
+export const handlers = [...profileHandlers, ...registerHandlers, ...loginHandlers];

--- a/mocks/handlers/profile.ts
+++ b/mocks/handlers/profile.ts
@@ -1,0 +1,16 @@
+import { UserProfileProps } from './../../types/user';
+import { rest } from 'msw';
+
+export const profileHandlers = [
+  rest.post<UserProfileProps>('/userprofile', (req, res, ctx) => {
+    return res(
+      ctx.status(200),
+      ctx.json({
+        success: true,
+        code: 200,
+        message: 'SUCCESS',
+        data: '회원가입 완료 8702f24c080d458a9b27185e1a86135d',
+      }),
+    );
+  }),
+];

--- a/pages/profile/alcohol.tsx
+++ b/pages/profile/alcohol.tsx
@@ -2,7 +2,7 @@ import Router from 'next/router';
 import Image from 'next/image';
 import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
-import { useRecoilState, useSetRecoilState } from 'recoil';
+import { useRecoilState } from 'recoil';
 
 import { userProfileState } from '../../core/recoil/userProfileAtom';
 

--- a/pages/profile/alcohol.tsx
+++ b/pages/profile/alcohol.tsx
@@ -27,11 +27,12 @@ export default function alcohol() {
     if (alcohol === '') setIsDisabled(true);
     else {
       setIsDisabled(false);
+      setUserProfile([...userProfile, { topic: 'alcohol', value: alcohol }]);
     }
-  });
+  }, [alcohol]);
   const handleContinueButton = () => {
-    setUserProfile({ topic: 'isDrink', value: alcohol });
-    userprofileAPI(userProfile);
+    console.log(userProfile);
+    userprofileAPI;
     Router.push('/profile/completed');
   };
   const handleOButton = () => {

--- a/pages/profile/alcohol.tsx
+++ b/pages/profile/alcohol.tsx
@@ -20,7 +20,6 @@ import { userprofileAPI } from '../../core/api/userprofileAPI';
 
 export default function alcohol() {
   const [userProfile, setUserProfile] = useRecoilState(userProfileState);
-  // const setUserProfile = useSetRecoilState(userProfileState);
   const [alcohol, setAlcohol] = useState('');
   const [isDisabled, setIsDisabled] = useState(true);
 

--- a/pages/profile/alcohol.tsx
+++ b/pages/profile/alcohol.tsx
@@ -2,6 +2,10 @@ import Router from 'next/router';
 import Image from 'next/image';
 import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
+import { useRecoilState, useSetRecoilState } from 'recoil';
+
+import { userProfileState } from '../../core/recoil/userProfileAtom';
+
 import Button from '../../components/Button';
 import ProgressBar from '../../components/ProgressBar';
 import Top from '../../components/Top';
@@ -12,15 +16,23 @@ import whiteX from '../../public/assets/icons/whiteX.svg';
 import InputContainer from '../../components/AnimationContainer';
 import Container from '../../components/Container';
 import Guide from '../../components/Guide';
+import { userprofileAPI } from '../../core/api/userprofileAPI';
 
 export default function alcohol() {
+  const [userProfile, setUserProfile] = useRecoilState(userProfileState);
+  // const setUserProfile = useSetRecoilState(userProfileState);
   const [alcohol, setAlcohol] = useState('');
   const [isDisabled, setIsDisabled] = useState(true);
+
   useEffect(() => {
     if (alcohol === '') setIsDisabled(true);
-    else setIsDisabled(false);
+    else {
+      setIsDisabled(false);
+    }
   });
   const handleContinueButton = () => {
+    setUserProfile({ topic: 'isDrink', value: alcohol });
+    userprofileAPI(userProfile);
     Router.push('/profile/completed');
   };
   const handleOButton = () => {

--- a/pages/profile/interest.tsx
+++ b/pages/profile/interest.tsx
@@ -21,7 +21,22 @@ export default function interest() {
   const [isError, setIsError] = useState(false);
   const [keywords, setKeywords] = useState<string[]>([]);
 
-  const interest = ['게임', '자기계발', '스포츠', '뷰티'];
+  const interest = [
+    '게임',
+    '자기계발',
+    '스포츠',
+    '뷰티',
+    '패션',
+    '테크',
+    '영화',
+    '음악',
+    '디자인',
+    '음식',
+    '예능',
+    '음료',
+    '여행',
+    '시사',
+  ];
 
   useEffect(() => {
     if (count === 0) {

--- a/pages/profile/interest.tsx
+++ b/pages/profile/interest.tsx
@@ -1,6 +1,9 @@
 import Router from 'next/router';
 import React, { useEffect, useState } from 'react';
 import { useSetRecoilState } from 'recoil';
+
+import { userProfileState } from '../../core/recoil/userProfileAtom';
+
 import InputContainer from '../../components/AnimationContainer';
 import Button from '../../components/Button';
 import Container from '../../components/Container';
@@ -9,7 +12,6 @@ import Keyword from '../../components/Keyword';
 import ProgressBar from '../../components/ProgressBar';
 import Top from '../../components/Top';
 import { ErrorText } from '../../components/UserInput';
-import { userProfileState } from '../../core/recoil/userProfileAtom';
 
 export default function interest() {
   const setUserProfile = useSetRecoilState(userProfileState);
@@ -33,7 +35,6 @@ export default function interest() {
       setIsDisabled(false);
       setIsError(false);
       setMsg('');
-      setUserProfile({ topic: 'interestKeyword', value: keywords });
     }
   });
 
@@ -48,6 +49,7 @@ export default function interest() {
   };
 
   const handleContinueButton = () => {
+    setUserProfile({ topic: 'interestKeyword', value: keywords });
     Router.push('/profile/alcohol');
   };
   return (

--- a/pages/profile/interest.tsx
+++ b/pages/profile/interest.tsx
@@ -15,6 +15,7 @@ import { ErrorText } from '../../components/UserInput';
 
 export default function interest() {
   const setUserProfile = useSetRecoilState(userProfileState);
+
   const [count, setCount] = useState(0);
   const [isDisabled, setIsDisabled] = useState(true);
   const [msg, setMsg] = useState('');
@@ -64,7 +65,13 @@ export default function interest() {
   };
 
   const handleContinueButton = () => {
-    setUserProfile({ topic: 'interestKeyword', value: keywords });
+    setUserProfile((prev: object[]) => [
+      ...prev,
+      {
+        topic: 'interest',
+        value: keywords,
+      },
+    ]);
     Router.push('/profile/alcohol');
   };
   return (

--- a/pages/profile/interest.tsx
+++ b/pages/profile/interest.tsx
@@ -1,5 +1,6 @@
 import Router from 'next/router';
 import React, { useEffect, useState } from 'react';
+import { useSetRecoilState } from 'recoil';
 import InputContainer from '../../components/AnimationContainer';
 import Button from '../../components/Button';
 import Container from '../../components/Container';
@@ -8,31 +9,42 @@ import Keyword from '../../components/Keyword';
 import ProgressBar from '../../components/ProgressBar';
 import Top from '../../components/Top';
 import { ErrorText } from '../../components/UserInput';
+import { userProfileState } from '../../core/recoil/userProfileAtom';
 
 export default function interest() {
+  const setUserProfile = useSetRecoilState(userProfileState);
   const [count, setCount] = useState(0);
   const [isDisabled, setIsDisabled] = useState(true);
   const [msg, setMsg] = useState('');
   const [isError, setIsError] = useState(false);
+  const [keywords, setKeywords] = useState<string[]>([]);
 
   const interest = ['게임', '자기계발', '스포츠', '뷰티'];
 
   useEffect(() => {
-    if (count <= 3 && count !== 0) {
-      setIsDisabled(false);
+    if (count === 0) {
+      setIsDisabled(true);
+      setIsError(false);
     } else if (count > 3) {
       setIsDisabled(true);
       setIsError(true);
       setMsg('3개 이하만 선택 가능합니다');
     } else {
-      setIsDisabled(true);
+      setIsDisabled(false);
       setIsError(false);
       setMsg('');
+      setUserProfile({ topic: 'interestKeyword', value: keywords });
     }
   });
 
-  const isClicked = (onclick: boolean) => {
-    onclick ? setCount(count - 1) : setCount(count + 1);
+  const handleOnClicked = (onclick: boolean, text: string) => {
+    if (onclick) {
+      setCount(count - 1);
+      setKeywords(keywords.filter((keyword) => keyword !== text));
+    } else {
+      setCount(count + 1);
+      setKeywords([text, ...keywords]);
+    }
   };
 
   const handleContinueButton = () => {
@@ -46,7 +58,7 @@ export default function interest() {
         <InputContainer>
           <Guide text="관심사 키워드를 선택해주세요" />
           {interest.map((text) => (
-            <Keyword key={text} text={text} isClicked={isClicked} />
+            <Keyword key={text} text={text} onClicked={handleOnClicked} />
           ))}
           {isError && (
             <ErrorText>

--- a/pages/profile/mbti.tsx
+++ b/pages/profile/mbti.tsx
@@ -1,5 +1,9 @@
 import Router from 'next/router';
 import React, { useEffect, useState } from 'react';
+import { useSetRecoilState } from 'recoil';
+
+import { userProfileState } from '../../core/recoil/userProfileAtom';
+
 import InputContainer from '../../components/AnimationContainer';
 import Button from '../../components/Button';
 import Container from '../../components/Container';
@@ -9,6 +13,7 @@ import Top from '../../components/Top';
 import UserInput, { ErrorText } from '../../components/UserInput';
 
 export default function mbti() {
+  const setUserProfile = useSetRecoilState(userProfileState);
   const [userMbti, setUserMbti] = useState('');
   const [isDisabled, setIsDisabled] = useState(true);
   const [msg, setMsg] = useState('');
@@ -26,6 +31,7 @@ export default function mbti() {
       setIsDisabled(false);
       setMsg('');
       setIsError(false);
+      setUserProfile({ topic: 'mbti', value: userMbti });
     }
   }, [userMbti]);
 

--- a/pages/profile/mbti.tsx
+++ b/pages/profile/mbti.tsx
@@ -36,10 +36,15 @@ export default function mbti() {
 
   const handleMbtiInput = (e: React.ChangeEvent<HTMLInputElement>) => {
     setUserMbti(e.target.value);
-    console.log(userMbti);
   };
   const handleContinueButton = () => {
-    setUserProfile({ topic: 'mbti', value: userMbti });
+    setUserProfile((prev: object[]) => [
+      ...prev,
+      {
+        topic: 'mbti',
+        value: userMbti,
+      },
+    ]);
     Router.push('/profile/interest');
   };
   return (

--- a/pages/profile/mbti.tsx
+++ b/pages/profile/mbti.tsx
@@ -31,14 +31,15 @@ export default function mbti() {
       setIsDisabled(false);
       setMsg('');
       setIsError(false);
-      setUserProfile({ topic: 'mbti', value: userMbti });
     }
   }, [userMbti]);
 
   const handleMbtiInput = (e: React.ChangeEvent<HTMLInputElement>) => {
     setUserMbti(e.target.value);
+    console.log(userMbti);
   };
   const handleContinueButton = () => {
+    setUserProfile({ topic: 'mbti', value: userMbti });
     Router.push('/profile/interest');
   };
   return (

--- a/types/user.ts
+++ b/types/user.ts
@@ -13,5 +13,5 @@ export interface RegisterProps {
 
 export interface UserProfileProps {
   topic: string;
-  value: string | object;
+  value: string | string[];
 }

--- a/types/user.ts
+++ b/types/user.ts
@@ -10,3 +10,8 @@ export interface RegisterProps {
   gender: string;
   university: string;
 }
+
+export interface UserProfileProps {
+  topic: string;
+  value: string | object;
+}


### PR DESCRIPTION
- userProfileAPI 추가
- userProfileAtom 추가 - `mbti` `interest` `alcohol` recoil 적용하고 마지막 `alcohol` 에서 api 통신했습니닷
- profile mock 핸들러 추가
- types에 `userProfileProps` 타입 추가

했습니당

- [x] recoil 수정 예정